### PR TITLE
Dockerfile: Add python to the container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ COPY . /app
 WORKDIR /app
 ARG GIT_SHA
 
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+
 RUN yarn install --network-timeout 1000000 --frozen-lockfile \
   && GIT_SHA=${GIT_SHA} yarn --debug --verbose run build
 
@@ -13,6 +16,9 @@ FROM node:22.8-alpine
 LABEL org.opencontainers.image.source=https://github.com/ketan/paragliding-meshmap
 LABEL org.opencontainers.image.description="Meshmap tracker for paragliding"
 LABEL org.opencontainers.image.licenses=MIT
+
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 
 COPY --from=build /app/package.json /app/yarn.lock /app/build /app/
 


### PR DESCRIPTION
Alpine doesn't appear to come with python by default, and the gyp installation requires python:

    gyp ERR! find Python
    gyp ERR! find Python Python is not set from command line or npm configuration
    gyp ERR! find Python Python is not set from environment variable PYTHON
    gyp ERR! find Python checking if \"python3\" can be used
    gyp ERR! find Python - \"python3\" is not in PATH or produced an error
    gyp ERR! find Python checking if \"python\" can be used
    gyp ERR! find Python - \"python\" is not in PATH or produced an error
    gyp ERR! find Python
    gyp ERR! find Python **********************************************************
    gyp ERR! find Python You need to install the latest version of Python.
    gyp ERR! find Python Node-gyp should be able to find and use Python. If not,

Thus we add the python3 alpine package in each image.