### PR TITLE
frontend: Color the activity nodes for fly and concern

### DIFF
--- a/frontend/src/templates/legend.tsx
+++ b/frontend/src/templates/legend.tsx
@@ -46,10 +46,19 @@ export function cssClassFor(str: NodeStatus | 'start-track' | 'end-track', activ
     case 'end-track':
       return `bg-amber-600 ${commonClasses}`
     case 'online':
-      return `bg-green-600 ${commonClasses}`
+      break; /* see below */
     case 'old':
       return `bg-purple-600 ${commonClasses}`
     case 'offline':
       return `bg-gray-600 ${commonClasses}`
+  }
+
+  switch(activity) {
+    case 'fly':
+      return `bg-blue-600 ${commonClasses}`
+    case 'concern':
+      return `bg-orange-600 ${commonClasses}`
+    default:
+      return `bg-green-600 ${commonClasses}`
   }
 }


### PR DESCRIPTION
Activity nodes for fly are now colored blue, and concern nodes are colored orange.

Request from Jigish Gohil: can you also add code for color coding Blue = Flying, Orange = concern and Green = Rest. Have removed hike and travel as we don't need them and they will give a lot of false positives due to gps always moving around.